### PR TITLE
feat/12 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/gbsb/tripmate/config/SecurityConfig.java
+++ b/src/main/java/com/gbsb/tripmate/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/meetings").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/src/main/java/com/gbsb/tripmate/controller/MeetingController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/MeetingController.java
@@ -1,11 +1,8 @@
 package com.gbsb.tripmate.controller;
 
-import com.gbsb.tripmate.dto.BaseResponse;
-import com.gbsb.tripmate.dto.MeetingCreateRequest;
-import com.gbsb.tripmate.dto.JoinMeeting;
-import com.gbsb.tripmate.dto.UpdateMeeting;
+import com.gbsb.tripmate.dto.*;
 import com.gbsb.tripmate.entity.Meeting;
-import com.gbsb.tripmate.entity.User;
+import com.gbsb.tripmate.service.CustomUserDetailsService;
 import com.gbsb.tripmate.service.MeetingService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,18 +14,13 @@ import lombok.RequiredArgsConstructor;
 public class MeetingController {
     private final MeetingService meetingService;
 
-    public MeetingController(MeetingService meetingService) {
-        this.meetingService = meetingService;
-    }
-
     // 모임 생성
     @PostMapping("/create")
-    public BaseResponse<Boolean> createGroup(@RequestBody MeetingCreateRequest request, @AuthenticationPrincipal User user) {
+    public BaseResponse<Boolean> createGroup(@RequestBody MeetingCreateRequest request, @AuthenticationPrincipal CustomUserDetailsService.CustomUserDetails user) {
         try {
             Meeting newMeeting = meetingService.createMeeting(user.getId(), request);
             return new BaseResponse<>("모임이 개설되었습니다.", true);
         } catch (Exception e) {
-            e.printStackTrace();
             return new BaseResponse<>("모임 개설에 실패했습니다.", false);
         }
     }
@@ -53,14 +45,37 @@ public class MeetingController {
   
     // 모임 삭제
     @DeleteMapping("/{meetingId}")
-    public BaseResponse<Boolean> deleteMeeting(@PathVariable long meetingId, @AuthenticationPrincipal User user) {
+    public BaseResponse<Boolean> deleteMeeting(@PathVariable long meetingId, @AuthenticationPrincipal CustomUserDetailsService.CustomUserDetails user) {
         try {
             meetingService.deleteMeeting(user.getId(), meetingId);
             return new BaseResponse<>("모임이 삭제되었습니다.", true);
         } catch (RuntimeException e) {
             return new BaseResponse<>(e.getMessage(), false);
         } catch (Exception e) {
-            e.printStackTrace();
             return new BaseResponse<>("모임 삭제에 실패했습니다.", false);
-        }  
+        }
+    }
+
+    // 모임 탈퇴
+    @DeleteMapping("/{meetingId}/leave")
+    public BaseResponse<Boolean> leaveMeeting(@PathVariable long meetingId, @AuthenticationPrincipal CustomUserDetailsService.CustomUserDetails user) {
+        try{
+            meetingService.leaveMeeting(user.getId(), meetingId);
+            return new BaseResponse<>("모임에서 탈퇴하였습니다.", true);
+        } catch (Exception e) {
+            return new BaseResponse<>(e.getMessage(), false);
+        }
+    }
+
+    // 멤버 내보내기
+    @PostMapping("/{meetingId}/remove-member")
+    public BaseResponse<Boolean> removeMember(@PathVariable long meetingId, @AuthenticationPrincipal CustomUserDetailsService.CustomUserDetails leader,
+                                              @RequestBody RemoveMemberRequest request) {
+        try {
+            meetingService.removeMember(leader.getId(), meetingId, request);
+            return new BaseResponse<>("멤버가 탈퇴되었습니다.", true);
+        } catch (Exception e) {
+            return new BaseResponse<>(e.getMessage(), false);
+        }
+    }
 }

--- a/src/main/java/com/gbsb/tripmate/controller/MeetingController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.gbsb.tripmate.dto.*;
 import com.gbsb.tripmate.entity.Meeting;
 import com.gbsb.tripmate.service.CustomUserDetailsService;
 import com.gbsb.tripmate.service.MeetingService;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,16 @@ public class MeetingController {
         } catch (Exception e) {
             return new BaseResponse<>("모임 개설에 실패했습니다.", false);
         }
+    }
+
+    // 모임 목록 조회
+    @GetMapping
+    public Page<MeetingResponse> getMeetings(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdDate") String sortBy
+    ) {
+        return meetingService.getAllMeetings(page, size, sortBy);
     }
 
     @PutMapping("/{meetingId}")

--- a/src/main/java/com/gbsb/tripmate/dto/MeetingResponse.java
+++ b/src/main/java/com/gbsb/tripmate/dto/MeetingResponse.java
@@ -1,0 +1,18 @@
+package com.gbsb.tripmate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class MeetingResponse {
+    private Long id;
+    private String meetingTitle;
+    private String meetingDescription;
+    private String destination;
+    private String leaderNickname;
+    private LocalDate travelStartDate;
+    private LocalDate travelEndDate;
+}

--- a/src/main/java/com/gbsb/tripmate/dto/RemoveMemberRequest.java
+++ b/src/main/java/com/gbsb/tripmate/dto/RemoveMemberRequest.java
@@ -1,0 +1,9 @@
+package com.gbsb.tripmate.dto;
+
+import lombok.Data;
+
+@Data
+public class RemoveMemberRequest {
+    private Long meetingMemberId;
+    private String reason;
+}

--- a/src/main/java/com/gbsb/tripmate/entity/Meeting.java
+++ b/src/main/java/com/gbsb/tripmate/entity/Meeting.java
@@ -68,7 +68,7 @@ public class Meeting {
         this.meetingDescription = tripGroup.getDescription();
         this.destination = tripGroup.getDestination();
         this.genderCondition = tripGroup.getGender();
-        this.ageRange = tripGroup.getAgeRange();
+        this.ageGroup = tripGroup.getAgeRange();
         this.travelStyle = tripGroup.getTravelStyle();
         this.memberMax = tripGroup.getMemberMax();
         this.travelStartDate = tripGroup.getTravelStartDate();

--- a/src/main/java/com/gbsb/tripmate/entity/MeetingMember.java
+++ b/src/main/java/com/gbsb/tripmate/entity/MeetingMember.java
@@ -26,11 +26,15 @@ public class MeetingMember {
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "meeting_id", referencedColumnName = "meetingId")
+    @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
     @Column(nullable = false)
     private LocalDate joinDate;
 
     private Boolean isLeader;
+
+    private String removeReason;
+
+    private Boolean isRemoved = false;
 }

--- a/src/main/java/com/gbsb/tripmate/repository/DailyParticipationRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/DailyParticipationRepository.java
@@ -1,15 +1,19 @@
 package com.gbsb.tripmate.repository;
 
 import com.gbsb.tripmate.entity.DailyParticipation;
+import com.gbsb.tripmate.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DailyParticipationRepository extends JpaRepository<DailyParticipation, Long> {
     @Query("SELECT dp.participationDate FROM DailyParticipation dp WHERE dp.user.id = :id")
     List<LocalDate> findParticipationDatesById(Long id);
+
+    Optional<DailyParticipation> findByUserAndParticipationDate(User user, LocalDate participationDate);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/MeetingMemberRepository.java
@@ -1,15 +1,21 @@
 package com.gbsb.tripmate.repository;
 
+import com.gbsb.tripmate.entity.Meeting;
 import com.gbsb.tripmate.entity.MeetingMember;
+import com.gbsb.tripmate.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Long> {
     // 멤버 수 조회
     @Query("SELECT COUNT(mm) FROM MeetingMember mm WHERE mm.meeting.meetingId = :meetingId")
     int countMembersByGroupId(@Param("meetingId") Long meetingId);
+
+    Optional<MeetingMember> findByMeetingAndUser(Meeting meeting, User user);
+    Optional<MeetingMember> findByMeetingAndUserId(Meeting meeting, Long userId);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/MeetingRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/MeetingRepository.java
@@ -1,9 +1,12 @@
 package com.gbsb.tripmate.repository;
 
 import com.gbsb.tripmate.entity.Meeting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    Page<Meeting> findAll(Pageable pageable);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/MeetingRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/MeetingRepository.java
@@ -4,9 +4,6 @@ import com.gbsb.tripmate.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
-
 }

--- a/src/main/java/com/gbsb/tripmate/service/CustomUserDetailsService.java
+++ b/src/main/java/com/gbsb/tripmate/service/CustomUserDetailsService.java
@@ -2,7 +2,6 @@ package com.gbsb.tripmate.service;
 
 import com.gbsb.tripmate.entity.User;
 import com.gbsb.tripmate.repository.UserRepository;
-import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -73,5 +72,8 @@ public class CustomUserDetailsService implements UserDetailsService {
             return user;
         }
 
+        public Long getId() {
+            return user.getId();
+        }
     }
 }

--- a/src/main/java/com/gbsb/tripmate/service/MeetingService.java
+++ b/src/main/java/com/gbsb/tripmate/service/MeetingService.java
@@ -12,6 +12,10 @@ import com.gbsb.tripmate.repository.MeetingMemberRepository;
 import com.gbsb.tripmate.repository.MeetingRepository;
 import com.gbsb.tripmate.repository.UserRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -62,6 +66,26 @@ public class MeetingService {
 
         meetingMemberRepository.save(leader);
         return savedMeeting;
+    }
+
+    // 모임 목록 조회
+    public Page<MeetingResponse> getAllMeetings(int page, int size, String sortBy) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortBy).ascending());
+        Page<Meeting> meetings = meetingRepository.findAll(pageable);
+
+        return meetings.map(this::convertToDto);
+    }
+
+    private MeetingResponse convertToDto(Meeting meeting) {
+        return new MeetingResponse(
+                meeting.getMeetingId(),
+                meeting.getMeetingTitle(),
+                meeting.getMeetingDescription(),
+                meeting.getDestination(),
+                meeting.getMeetingLeader().getNickname(),
+                meeting.getTravelStartDate(),
+                meeting.getTravelEndDate()
+        );
     }
 
     // 모임 삭제
@@ -210,7 +234,6 @@ public class MeetingService {
         // 모임장인지 확인
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUNT));
-        
 
         if (!meeting.getMeetingLeader().getId().equals(leaderId)) {
             throw new RuntimeException("모임장만 멤버를 탈퇴시킬 수 있습니다.");


### PR DESCRIPTION
## Related issue 🛠
- closed #12 

## Work Description ✏️
- 모임 목록 조회를 페이징 처리를 통해 구현했습니다.
- 파라미터를 통해 페이지 번호 (page), 한 페이지당 조회되는 컨텐츠의 갯수(size), 정렬기준(sortBy)을 설정할 수 있습니다.

## To Reviewers 📢
- 총 6개의 모임을 한 페이지당 3개씩 조회 총 2페이지
<img width="1142" alt="스크린샷 2024-09-25 오전 3 39 28" src="https://github.com/user-attachments/assets/83cdd3b4-4ba5-40ce-a12e-41c1cdac2ec2">
<img width="872" alt="스크린샷 2024-09-25 오전 3 38 58" src="https://github.com/user-attachments/assets/5efc951f-a619-4793-a6f6-ae5c6bad75fa">
<img width="857" alt="스크린샷 2024-09-25 오전 3 39 14" src="https://github.com/user-attachments/assets/a4be1eec-c53b-4233-ab45-c90e808f2fa2">
