### PR TITLE
Feature/23: 세부 일정 조회 및 삭제 api 구현

### DIFF
--- a/src/main/java/com/gbsb/tripmate/controller/PlanController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/PlanController.java
@@ -47,5 +47,11 @@ public class PlanController {
         return new BaseResponse<>("세부 일정 조회에 성공했습니다.", planItemResponseList);
     }
 
-    // 세부 일정 삭제 -> itemOrder 재정렬 필요
+    @PutMapping("/{planItemId}")
+    BaseResponse<Boolean> deletePlanItem(
+        @PathVariable Long planItemId
+    ){
+        travelPlanService.deletePlanItem(planItemId);
+        return new BaseResponse<>("세부 일정 삭제에 성공했습니다", true);
+    }
 }

--- a/src/main/java/com/gbsb/tripmate/controller/PlanController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/PlanController.java
@@ -3,10 +3,13 @@ package com.gbsb.tripmate.controller;
 import com.gbsb.tripmate.dto.BaseResponse;
 import com.gbsb.tripmate.dto.PlanCreate;
 import com.gbsb.tripmate.dto.PlanItemCreate;
+import com.gbsb.tripmate.dto.PlanItemResponse;
 import com.gbsb.tripmate.entity.PlanItem;
 import com.gbsb.tripmate.service.TravelPlanService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +36,14 @@ public class PlanController {
     ) {
         travelPlanService.createPlanItem(meetingId, travelPlanId, request);
         return new BaseResponse<>("세부 일정을 생성했습니다.", null);
+    }
+
+    // 세부 일정 조회
+    @GetMapping("/{travelPlanId}")
+    BaseResponse<List<PlanItemResponse>> getPlanItem(
+            @PathVariable Long travelPlanId
+    ){
+        List<PlanItemResponse> planItemResponseList = travelPlanService.getPlanItemDetail(travelPlanId);
+        return new BaseResponse<>("세부 일정 조회에 성공했습니다.", planItemResponseList);
     }
 }

--- a/src/main/java/com/gbsb/tripmate/controller/PlanController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/PlanController.java
@@ -46,4 +46,6 @@ public class PlanController {
         List<PlanItemResponse> planItemResponseList = travelPlanService.getPlanItemDetail(travelPlanId);
         return new BaseResponse<>("세부 일정 조회에 성공했습니다.", planItemResponseList);
     }
+
+    // 세부 일정 삭제 -> itemOrder 재정렬 필요
 }

--- a/src/main/java/com/gbsb/tripmate/controller/PlanController.java
+++ b/src/main/java/com/gbsb/tripmate/controller/PlanController.java
@@ -29,21 +29,21 @@ public class PlanController {
 
     // 세부 일정 추가
     @PostMapping("/{meetingId}/{travelPlanId}")
-    BaseResponse<PlanItem> addPlanItem(
+    BaseResponse<Boolean> addPlanItem(
             @PathVariable Long meetingId,
             @PathVariable Long travelPlanId,
             @RequestBody PlanItemCreate.Request request
     ) {
         travelPlanService.createPlanItem(meetingId, travelPlanId, request);
-        return new BaseResponse<>("세부 일정을 생성했습니다.", null);
+        return new BaseResponse<>("세부 일정을 생성했습니다.", true);
     }
 
     // 세부 일정 조회
-    @GetMapping("/{travelPlanId}")
+    @GetMapping("/{planItemId}")
     BaseResponse<List<PlanItemResponse>> getPlanItem(
-            @PathVariable Long travelPlanId
+            @PathVariable Long planItemId
     ){
-        List<PlanItemResponse> planItemResponseList = travelPlanService.getPlanItemDetail(travelPlanId);
+        List<PlanItemResponse> planItemResponseList = travelPlanService.getPlanItemDetail(planItemId);
         return new BaseResponse<>("세부 일정 조회에 성공했습니다.", planItemResponseList);
     }
 

--- a/src/main/java/com/gbsb/tripmate/dto/PlanItemResponse.java
+++ b/src/main/java/com/gbsb/tripmate/dto/PlanItemResponse.java
@@ -1,0 +1,23 @@
+package com.gbsb.tripmate.dto;
+
+import com.gbsb.tripmate.enums.TravelStyle;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Builder
+public class PlanItemResponse {
+    private Long planItemId;
+    private LocalDate planDate;
+    private String itemName;
+    private TravelStyle itemType;
+    private String itemDescription;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private int itemOrder;
+}

--- a/src/main/java/com/gbsb/tripmate/entity/DailyParticipation.java
+++ b/src/main/java/com/gbsb/tripmate/entity/DailyParticipation.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 
@@ -25,4 +26,7 @@ public class DailyParticipation {
 
     @Column(nullable = false)
     private LocalDate participationDate;
+
+    @ColumnDefault("false")
+    private boolean isDeleted;
 }

--- a/src/main/java/com/gbsb/tripmate/entity/User.java
+++ b/src/main/java/com/gbsb/tripmate/entity/User.java
@@ -1,6 +1,6 @@
 package com.gbsb.tripmate.entity;
 
-import com.gbsb.tripmate.enums.AgeGroup;
+import com.gbsb.tripmate.enums.AgeRange;
 import com.gbsb.tripmate.enums.Gender;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -42,7 +42,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private AgeGroup ageGroup;
+    private AgeRange ageRange;
 
     @Column(nullable = false)
     private String name;
@@ -59,17 +59,17 @@ public class User {
     private void calculateAgeGroup() {
         if (this.birthdate != null) {
             int age = LocalDate.now().getYear() - this.birthdate.getYear();
-            this.ageGroup = getAgeGroupFromAge(age);
+            this.ageRange = getAgeGroupFromAge(age);
         }
     }
 
-    private AgeGroup getAgeGroupFromAge(int age) {
-        if (age < 20) return AgeGroup.TEENS;
-        else if (age < 30) return AgeGroup.TWENTIES;
-        else if (age < 40) return AgeGroup.THIRTIES;
-        else if (age < 50) return AgeGroup.FORTIES;
-        else if (age < 60) return AgeGroup.FIFTIES;
-        else return AgeGroup.SIXTIES_PLUS;
+    private AgeRange getAgeGroupFromAge(int age) {
+        if (age < 20) return AgeRange.TEEN;
+        else if (age < 30) return AgeRange.TWENTIES;
+        else if (age < 40) return AgeRange.THIRTIES;
+        else if (age < 50) return AgeRange.FORTIES;
+        else if (age < 60) return AgeRange.FIFTIES;
+        else return AgeRange.SIXTIES_PLUS;
     }
 }
 

--- a/src/main/java/com/gbsb/tripmate/enums/ErrorCode.java
+++ b/src/main/java/com/gbsb/tripmate/enums/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     PLAN_NOT_FOUND("해당하는 여행 계획이 없습니다."),
     PLACE_NOT_FOUND("해당 장소는 없는 장소입니다."),
     INVALID_ITEM_ORDER("해당 순서는 존재하지 않습니다."),
-    ALREADY_SAME_START_TIME_EXIST("해당 시간에 시작하는 여행 계획이 존재합니다.");
+    ALREADY_SAME_START_TIME_EXIST("해당 시간에 시작하는 여행 계획이 존재합니다."),
+    PLAN_ITEM_ID_NOT_FOUND("해당 세부 일정이 없습니다.");
 
     private final String description;
 }

--- a/src/main/java/com/gbsb/tripmate/repository/DailyParticipationRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/DailyParticipationRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 @Repository
 public interface DailyParticipationRepository extends JpaRepository<DailyParticipation, Long> {
-    @Query("SELECT dp.participationDate FROM DailyParticipation dp WHERE dp.user.id = :id")
+    @Query("SELECT dp.participationDate FROM DailyParticipation dp WHERE dp.user.id = :id AND dp.isDeleted = false")
     List<LocalDate> findParticipationDatesById(Long id);
 
-    Optional<DailyParticipation> findByUserAndParticipationDate(User user, LocalDate participationDate);
+    Optional<DailyParticipation> findByUserAndParticipationDateAndIsDeletedFalse(User user, LocalDate participationDate);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PlanItemRepository extends JpaRepository<PlanItem, Long> {
     List<PlanItem> findByTravelPlanAndIsDeletedFalseOrderByStartTimeAsc(TravelPlan travelPlan);
     List<PlanItem> findAllByTravelPlanAndIsDeletedFalseOrderByItemOrderAsc(TravelPlan travelPlan);
+    Optional<PlanItem> findByPlanItemIdAndIsDeletedFalse(Long travelPlanId);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 @Repository
 public interface PlanItemRepository extends JpaRepository<PlanItem, Long> {
-    List<PlanItem> findByTravelPlanOrderByStartTimeAsc(TravelPlan travelPlan);
-    List<PlanItem> findAllByTravelPlanOrderByItemOrderAsc(TravelPlan travelPlan);
+    List<PlanItem> findByTravelPlanAndIsDeletedFalseOrderByStartTimeAsc(TravelPlan travelPlan);
+    List<PlanItem> findAllByTravelPlanAndIsDeletedFalseOrderByItemOrderAsc(TravelPlan travelPlan);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/PlanItemRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface PlanItemRepository extends JpaRepository<PlanItem, Long> {
     List<PlanItem> findByTravelPlanOrderByStartTimeAsc(TravelPlan travelPlan);
+    List<PlanItem> findAllByTravelPlanOrderByItemOrderAsc(TravelPlan travelPlan);
 }

--- a/src/main/java/com/gbsb/tripmate/repository/TravelPlanRepository.java
+++ b/src/main/java/com/gbsb/tripmate/repository/TravelPlanRepository.java
@@ -13,10 +13,10 @@ import java.util.List;
 @Repository
 public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
 
-    List<TravelPlan> findAllByMeeting(Meeting meeting);
+    List<TravelPlan> findAllByMeetingAndIsDeletedFalse(Meeting meeting);
 
     @Query("SELECT MIN(tp.planDate) FROM TravelPlan tp WHERE tp.meeting.meetingId IN "
             + "(SELECT mm.meeting.meetingId FROM MeetingMember mm WHERE mm.user.Id = :Id) "
-            + "AND tp.planDate > CURRENT_DATE")
+            + "AND tp.planDate > CURRENT_DATE AND tp.isDeleted = false")
     LocalDate findNextTravelDateByUserId(@Param("Id") Long Id);
 }

--- a/src/main/java/com/gbsb/tripmate/service/MeetingService.java
+++ b/src/main/java/com/gbsb/tripmate/service/MeetingService.java
@@ -135,6 +135,7 @@ public class MeetingService {
             }
 
             meeting.setTripGroup(request);
+            meeting.setUpdatedDate(LocalDate.now());
             meetingRepository.save(meeting);
         }
 
@@ -220,7 +221,7 @@ public class MeetingService {
             List<LocalDate> participationDates = dailyParticipationRepository.findParticipationDatesById(user.getId());
 
             for (LocalDate participationDate : participationDates) {
-                DailyParticipation dailyParticipation = dailyParticipationRepository.findByUserAndParticipationDate(user, participationDate)
+                DailyParticipation dailyParticipation = dailyParticipationRepository.findByUserAndParticipationDateAndIsDeletedFalse(user, participationDate)
                         .orElseThrow(() -> new RuntimeException("해당 날짜의 참여 데이터가 없습니다."));
 
                 dailyParticipationRepository.delete(dailyParticipation);
@@ -251,7 +252,7 @@ public class MeetingService {
             List<LocalDate> participationDates = dailyParticipationRepository.findParticipationDatesById(member.getUser().getId());
 
             for (LocalDate participationDate : participationDates) {
-                DailyParticipation dailyParticipation = dailyParticipationRepository.findByUserAndParticipationDate(member.getUser(), participationDate)
+                DailyParticipation dailyParticipation = dailyParticipationRepository.findByUserAndParticipationDateAndIsDeletedFalse(member.getUser(), participationDate)
                         .orElseThrow(() -> new RuntimeException("해당 날짜의 참여 데이터가 없습니다."));
 
                 dailyParticipationRepository.delete(dailyParticipation);

--- a/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
+++ b/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
@@ -2,6 +2,7 @@ package com.gbsb.tripmate.service;
 
 import com.gbsb.tripmate.dto.PlanCreate;
 import com.gbsb.tripmate.dto.PlanItemCreate;
+import com.gbsb.tripmate.dto.PlanItemResponse;
 import com.gbsb.tripmate.entity.Meeting;
 import com.gbsb.tripmate.entity.Place;
 import com.gbsb.tripmate.entity.TravelPlan;
@@ -16,6 +17,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -94,5 +96,27 @@ public class TravelPlanService {
                 .itemOrder(newOrder)
                 .build();
         planItemRepository.save(planItem);
+    }
+
+    public List<PlanItemResponse> getPlanItemDetail(Long travelPlanId) {
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new MeetingException(ErrorCode.PLAN_NOT_FOUND));
+
+        List<PlanItem> planItemList = planItemRepository.findAllByTravelPlanOrderByItemOrderAsc(travelPlan);
+        List<PlanItemResponse> planItemResponseList = new ArrayList<>();
+        for (PlanItem plan : planItemList) {
+            PlanItemResponse planItemResponse = PlanItemResponse.builder()
+                    .planItemId(plan.getPlanItemId())
+                    .planDate(plan.getTravelPlan().getPlanDate())
+                    .itemName(plan.getItemName())
+                    .itemType(plan.getItemType())
+                    .itemDescription(plan.getItemDescription())
+                    .startTime(plan.getStartTime())
+                    .endTime(plan.getEndTime())
+                    .itemOrder(plan.getItemOrder())
+                    .build();
+            planItemResponseList.add(planItemResponse);
+        }
+        return planItemResponseList;
     }
 }

--- a/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
+++ b/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
@@ -119,4 +119,25 @@ public class TravelPlanService {
         }
         return planItemResponseList;
     }
+
+    public void deletePlanItem(Long planItemId) {
+        PlanItem planItem = planItemRepository.findByPlanItemIdAndIsDeletedFalse(planItemId)
+                .orElseThrow(() -> new MeetingException(ErrorCode.PLAN_ITEM_ID_NOT_FOUND));
+        planItem.setDeleted(true);
+        planItem.setItemOrder(-1);
+
+        // itemOrder 재정렬
+        Long travelPlanId = planItem.getTravelPlan().getTravelPlanId();
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new MeetingException(ErrorCode.PLAN_NOT_FOUND));
+        List<PlanItem> planItemList = planItemRepository.findByTravelPlanAndIsDeletedFalseOrderByStartTimeAsc(travelPlan);
+
+        int itemOrder = 1;
+        for (PlanItem item: planItemList) {
+            item.setItemOrder(itemOrder++);
+            planItemRepository.save(item);
+        }
+
+        planItemRepository.save(planItem);
+    }
 }

--- a/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
+++ b/src/main/java/com/gbsb/tripmate/service/TravelPlanService.java
@@ -33,7 +33,7 @@ public class TravelPlanService {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
 
-        List<TravelPlan> travelPlanList = travelPlanRepository.findAllByMeeting(meeting);
+        List<TravelPlan> travelPlanList = travelPlanRepository.findAllByMeetingAndIsDeletedFalse(meeting);
         for (TravelPlan value : travelPlanList) {
             if (value.getPlanDate().equals(request.getPlanDate())) {
                 throw new MeetingException(ErrorCode.ALREADY_DATE_EXIST);
@@ -55,7 +55,7 @@ public class TravelPlanService {
         TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.PLAN_NOT_FOUND));
 
-        List<PlanItem> planItemList = planItemRepository.findByTravelPlanOrderByStartTimeAsc(travelPlan);
+        List<PlanItem> planItemList = planItemRepository.findByTravelPlanAndIsDeletedFalseOrderByStartTimeAsc(travelPlan);
 
         Place place = placeRepository.findById(request.getPlaceId())
                 .orElseThrow(() -> new MeetingException(ErrorCode.PLACE_NOT_FOUND));
@@ -102,7 +102,7 @@ public class TravelPlanService {
         TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.PLAN_NOT_FOUND));
 
-        List<PlanItem> planItemList = planItemRepository.findAllByTravelPlanOrderByItemOrderAsc(travelPlan);
+        List<PlanItem> planItemList = planItemRepository.findAllByTravelPlanAndIsDeletedFalseOrderByItemOrderAsc(travelPlan);
         List<PlanItemResponse> planItemResponseList = new ArrayList<>();
         for (PlanItem plan : planItemList) {
             PlanItemResponse planItemResponse = PlanItemResponse.builder()


### PR DESCRIPTION
## Related issue 🛠
- closed #23 

## Work Description ✏️
- 세부 일정 조회 api
- 세부 일정 삭제 api
 : 삭제된 일정은 itemOrder을 -1로 지정하고 나머지 planitem의 order을 재정렬했습니다

## To Reviewers 📢
1. 세부 일정 조회
![image](https://github.com/user-attachments/assets/92e81810-1332-4f6e-910d-da5fcb9e8ab2)

2. 세부 일정 삭제
![image](https://github.com/user-attachments/assets/013b8495-2747-4146-bef0-24705204f287)
